### PR TITLE
Refactored code of themen collecting

### DIFF
--- a/app/Http/Controllers/TopicController.php
+++ b/app/Http/Controllers/TopicController.php
@@ -60,7 +60,7 @@ class TopicController extends Controller
         return new TopicWithData($paper);
     }
 
-    public function themen(Request $request)
+    public function themenOverview(Request $request)
     {
         $postalCode = $request->input('postalCode');
         $district = $request->input('district');
@@ -111,12 +111,29 @@ class TopicController extends Controller
         ]);
     }
 
-    public function newThemes(Request $request)
+    public function themen(Request $request)
     {
         $postalCode = $request->input('postalCode');
+
         $district = $request->input('district');
 
-        $paperQuery = Paper::with(Paper::$basicScope)->sort()->new();
+        $section=$request->input('section');
+
+        if($section === 'new'){
+            $paperQuery = Paper::with(Paper::$basicScope)->sort()->new();
+            $breadcrumbs = ['Neue Themen' => route('themes')];
+        }
+
+        if($section === 'updated'){
+            $paperQuery = Paper::with(Paper::$basicScope)->sort()->updated();
+            $breadcrumbs = ['Aktualisierte Themen' => route('themes')];
+        }
+
+        if($section === 'finished'){
+            $paperQuery = Paper::with(Paper::$basicScope)->sort()->finished();
+            $breadcrumbs = ['Abgeschlossene Themen' => route('themes')];
+        }
+
 
         if ($postalCode) {
             $paperQuery->whereHas('locations', function (Builder $query) use ($postalCode) {
@@ -134,85 +151,13 @@ class TopicController extends Controller
 
         return view('theme-list')->with([
             'theme_list' => $topics->data,
-            'theme_type' => 'new',
+            'theme_type' => $section,
             'district_list' => [
                 'Innenstadt', 'Rodenkirchen', 'Lindenthal', 'Ehrenfeld',
                 'Nippes',  'Chorweiler', 'Porz',  'Kalk',  'Mülheim'
             ],
             'links' => $topics->links,
-            'breadcrumbs' => [
-                'Neue Themen' => route('new-themes')
-            ]
-        ]);
-    }
-
-    public function progressThemes(Request $request)
-    {
-        $postalCode = $request->input('postalCode');
-        $district = $request->input('district');
-
-        $paperQuery = Paper::with(Paper::$basicScope)->sort()->updated();
-
-        if ($postalCode) {
-            $paperQuery->whereHas('locations', function (Builder $query) use ($postalCode) {
-                $query->where('postal_code', '=', $postalCode);
-            });
-        }
-
-        if ($district) {
-            $paperQuery->whereHas('locations', function (Builder $query) use ($district) {
-                $query->where('sub_locality', '=', $district);
-            });
-        }
-
-        $topics = TopicWithData::collection($paperQuery->paginate(15))->toResponse(request())->getData();
-
-        return view('theme-list')->with([
-            'theme_list' => $topics->data,
-            'theme_type' => 'updated',
-            'district_list' => [
-                'Innenstadt', 'Rodenkirchen', 'Lindenthal', 'Ehrenfeld',
-                'Nippes',  'Chorweiler', 'Porz',  'Kalk',  'Mülheim'
-            ],
-            'links' => $topics->links,
-            'breadcrumbs' => [
-                'Kürzlich aktualisiert' => route('progress-themes')
-            ]
-        ]);
-    }
-
-    public function finishedThemes(Request $request)
-    {
-        $postalCode = $request->input('postalCode');
-        $district = $request->input('district');
-
-        $paperQuery = Paper::with(Paper::$basicScope)->sort()->finished();
-
-        if ($postalCode) {
-            $paperQuery->whereHas('locations', function (Builder $query) use ($postalCode) {
-                $query->where('postal_code', '=', $postalCode);
-            });
-        }
-
-        if ($district) {
-            $paperQuery->whereHas('locations', function (Builder $query) use ($district) {
-                $query->where('sub_locality', '=', $district);
-            });
-        }
-
-        $topics = TopicWithData::collection($paperQuery->paginate(15))->toResponse(request())->getData();
-
-        return view('theme-list')->with([
-            'theme_list' => $topics->data,
-            'theme_type' => 'finished',
-            'district_list' => [
-                'Innenstadt', 'Rodenkirchen', 'Lindenthal', 'Ehrenfeld',
-                'Nippes',  'Chorweiler', 'Porz',  'Kalk',  'Mülheim'
-            ],
-            'links' => $topics->links,
-            'breadcrumbs' => [
-                'Kürzlich abgeschlossen' => route('finished-themes')
-            ]
+            'breadcrumbs' => $breadcrumbs,
         ]);
     }
 }

--- a/resources/views/layouts/header.blade.php
+++ b/resources/views/layouts/header.blade.php
@@ -44,9 +44,7 @@
                             <li>
                                 <a class="ris-nav__link
                                     @if (url()->current() === route('theme-overview')
-                                        or url()->current() === route('new-themes')
-                                        or url()->current() === route('progress-themes')
-                                        or url()->current() === route('finished-themes')
+                                        or url()->current() === route('themes')
                                     )
                                         ris-nav__link_active
                                     @endif"

--- a/resources/views/theme-list.blade.php
+++ b/resources/views/theme-list.blade.php
@@ -12,9 +12,9 @@
             <div class="ris-theme-list__content ris-content ris-content_six-eight-eight">
                 <section class="ris-section-wrapper">
                     <h1 class="ris-headline">
-                        @if (url()->current() === route('progress-themes'))
+                        @if ($theme_type === 'updated')
                             Kürzlich aktualisiert
-                        @elseif (url()->current() === route('finished-themes'))
+                        @elseif ($theme_type === 'finished')
                             Kürzlich abgeschlossen
                         @else
                             Neue Themen
@@ -54,9 +54,9 @@
                 <section class="ris-section-wrapper ris-card-list ris-card-list__themes">
                     <theme-component-lazy
                         :theme-list-type="
-                            @if (url()->current() === route('progress-themes'))
+                            @if ($theme_type === 'updated')
                                 'updated'
-                            @elseif (url()->current() === route('finished-themes'))
+                            @elseif ($theme_type === 'finished')
                                 'finished'
                             @else
                                 'new'

--- a/resources/views/theme-overview.blade.php
+++ b/resources/views/theme-overview.blade.php
@@ -15,15 +15,6 @@
 
                     <div class="ris-action-box">
                         <collapse></collapse>
-                        <dropdown
-                            :id="'theme-dropdown'"
-                            label="Sortierung"
-                            :value="{label: 'Fortschritt', value: 'Fortschritt'}"
-                            :options="[
-                                {label: 'Einstellungsdatum', value: 'Einstellungsdatum'},
-                                {label: 'Fortschritt', value: 'Fortschritt'}
-                            ]"
-                        ></dropdown>
                     </div>
                 </section>
 
@@ -81,7 +72,7 @@
                             ['theme_list' => $topics_new, 'theme_type' => 'new', 'limit' => 3]
                         )
 
-                        <a href="{{ route('new-themes') }}" class="ris-link ris-link_button ris-link_right"
+                        <a href="{{ route('themes', 'section=new') }}" class="ris-link ris-link_button ris-link_right"
                             title="Mehr anzeigen"
                         >
                             Mehr anzeigen
@@ -101,7 +92,7 @@
                                 ['theme_list' => $topics_progress, 'theme_type' => 'updated', 'limit' => 3]
                             )
 
-                        <a href="{{ route('progress-themes') }}" class="ris-link ris-link_button ris-link_right"
+                        <a href="{{ route('themes', 'section=updated') }}" class="ris-link ris-link_button ris-link_right"
                             title="Mehr anzeigen"
                         >
                             Mehr anzeigen
@@ -121,7 +112,7 @@
                                 ['theme_list' => $topics_finished, 'theme_type' => 'finished', 'limit' => 3]
                             )
 
-                        <a href="{{ route('finished-themes') }}" class="ris-link ris-link_button ris-link_right"
+                        <a href="{{ route('themes', 'section=finished') }}" class="ris-link ris-link_button ris-link_right"
                             title="Mehr anzeigen"
                         >
                             Mehr anzeigen

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,17 +24,11 @@ Route::group(['middleware' => 'under-construction'], function () {
     Route::get('/meeting/{id}', 'MeetingController@getMeeting')
         ->name('meeting');
 
-    Route::get('/themen-overview', 'TopicController@themen')
+    Route::get('/themen-overview', 'TopicController@themenOverview')
         ->name('theme-overview');
 
-    Route::get('/neue-themen', 'TopicController@newThemes')
-        ->name('new-themes');
-
-    Route::get('/aktualisiert-themen', 'TopicController@progressThemes')
-        ->name('progress-themes');
-
-    Route::get('/abgeschlossen-themen', 'TopicController@finishedThemes')
-        ->name('finished-themes');
+    Route::get('/themen', 'TopicController@themen')
+        ->name('themes');
 
     Route::get('/thema/{paper}', 'TopicController@topic')
         ->name('theme');


### PR DESCRIPTION
Refactored some code of themes collecting for theme-list and changed the route of theme-list

Commit Messages:
backend themes structure change;
replaced new finished updated route with themen;
replaced same functions with themen function;
adjusted frontend to new route adjusted header for breadcrumbs;
adjusted links in theme-overview

@MBeckers i couldn't figure out how to replace the current sorting of the dropdown. so that it is basically reloading and collecting data depending on the selection ( new, updated, finished ). Maybe someone who has further knowledge in the current frontend code knows how to do it.