### PR TITLE
Feature/remove images from all themen cards

### DIFF
--- a/resources/js/components/Theme/ThemeWidget.vue
+++ b/resources/js/components/Theme/ThemeWidget.vue
@@ -31,10 +31,8 @@ export default {
         class="ris-theme-item"
         :href="'/thema/' + topic.id"
         :title="topic.name">
-        <img src="/img/thumbnail-bridge-big-tile.png" class="ris-theme-item__image" alt="theme image">
         <div class="ris-theme-item__content">
             <div class="ris-theme-item__wrapper">
-                <img src="/img/thumbnail-bridge-big-tile.png" class="ris-theme-item__image-mobi" alt="theme image">
                 <h3 class="ris-theme-item__title" v-html="selectionFilter(topic.name)" />
             </div>
             <div class="ris-theme-item__info">

--- a/resources/views/theme-overview.blade.php
+++ b/resources/views/theme-overview.blade.php
@@ -33,8 +33,6 @@
                                         href="{{ route('theme', $topic->id) }}"
                                     >
                                         <div class="ris-top-card-list__item-top">
-                                            <img src="/img/thumbnail-bridge-big-tile.png" loading="lazy"
-                                                class="ris-top-card-list__item-img" alt="{{ $topic->name }}"/>
                                             <div class="ris-body-1">
                                                 {{ $topic->name }}
                                             </div>

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -37,6 +37,8 @@ mix.webpackConfig({
                         options: mix.config.babel(),
                     },
                 ],
+                // don't exclude node_modules it generate IE11 syntax error
+                // exclude /node_modules/
             },
         ],
     },


### PR DESCRIPTION
- removed images from the top themes
- removed images from the themes on the desktop and mobile version in search result
- added IE11 notice(fixed /yarn prod/ error with compressed js)

![theme-overview__without_images](https://user-images.githubusercontent.com/4416590/69237568-9f165280-0b9e-11ea-8487-72c77532a36b.png)
