### PR TITLE
Start Page - Link Topics to Card, closed #82

### DIFF
--- a/app/Http/Controllers/MainPageController.php
+++ b/app/Http/Controllers/MainPageController.php
@@ -34,7 +34,11 @@ class MainPageController extends Controller
         return view('welcome')->with([
             'meetings' => $meetings->data,
             'topics' => $topics->data,
-            'people' => $people->data
+            'people' => $people->data,
+            'district_list' => [
+                'Chorweiler', 'Ehrenfeld', 'Innenstadt', 'Kalk',
+                'Lindenthal', 'Mülheim', 'Nippes', 'Porz', 'Rodenkirchen'
+            ],
         ]);
     }
 

--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -35,8 +35,8 @@ class MapController extends Controller
         return view('map')->with([
             'topics' => $topics->data,
             'district_list' => [
-                'Innenstadt', 'Rodenkirchen', 'Lindenthal', 'Ehrenfeld',
-                'Nippes',  'Chorweiler', 'Porz',  'Kalk',  'Mülheim'
+                'Chorweiler', 'Ehrenfeld', 'Innenstadt', 'Kalk',
+                'Lindenthal', 'Mülheim', 'Nippes', 'Porz', 'Rodenkirchen'
             ],
             'links' => $topics->links,
             'breadcrumbs' => [

--- a/app/Http/Controllers/TopicController.php
+++ b/app/Http/Controllers/TopicController.php
@@ -165,8 +165,8 @@ class TopicController extends Controller
             'topics_finished' => $finished->data,
             'topic_title' => $topicTitle,
             'district_list' => [
-                'Innenstadt', 'Rodenkirchen', 'Lindenthal', 'Ehrenfeld',
-                'Nippes',  'Chorweiler', 'Porz',  'Kalk',  'Mülheim'
+                'Chorweiler', 'Ehrenfeld', 'Innenstadt', 'Kalk',
+                'Lindenthal', 'Mülheim', 'Nippes', 'Porz', 'Rodenkirchen'
             ],
             'links' => $topics->links,
             'breadcrumbs' => [
@@ -224,8 +224,8 @@ class TopicController extends Controller
             'theme_type' => $section,
             'topic_title' => $topicTitle,
             'district_list' => [
-                'Innenstadt', 'Rodenkirchen', 'Lindenthal', 'Ehrenfeld',
-                'Nippes',  'Chorweiler', 'Porz',  'Kalk',  'Mülheim'
+                'Chorweiler', 'Ehrenfeld', 'Innenstadt', 'Kalk',
+                'Lindenthal', 'Mülheim', 'Nippes', 'Porz', 'Rodenkirchen'
             ],
             'links' => $topics->links,
             'breadcrumbs' => $breadcrumbs,

--- a/resources/js/components/Map/MapAside.vue
+++ b/resources/js/components/Map/MapAside.vue
@@ -31,6 +31,10 @@ export default {
             type: Object,
             default: () => {},
         },
+        districtQuery: {
+            type: String,
+            default: '',
+        }
     },
     methods: {
         async getThemes () {
@@ -136,7 +140,11 @@ export default {
         }
     },
     created() {
-        this.getThemes();
+        if (this.districtQuery) {
+            this.getDistrictThemes(this.districtQuery);
+        } else {
+            this.getThemes();
+        }
     }
 };
 </script>
@@ -146,6 +154,7 @@ export default {
         <map-aside-navigation
             @changeDirection="changeDirection"
             :call-navigation="callNavigation"
+            :district-query="districtQuery"
             @mouse-handle="$emit('mouse-handle', $event)"
             @click-handle="$emit('click-handle', $event)"
             @theme-all-district-postcode-list="$emit('theme-all-district-postcode-list', $event)"

--- a/resources/js/components/Map/MapAsideBreadcrumbs.vue
+++ b/resources/js/components/Map/MapAsideBreadcrumbs.vue
@@ -27,6 +27,9 @@ export default {
         optionList () {
             this.checkList();
         }
+    },
+    created() {
+        this.checkList();
     }
 };
 </script>

--- a/resources/js/components/Map/MapAsideNavigation.vue
+++ b/resources/js/components/Map/MapAsideNavigation.vue
@@ -18,6 +18,10 @@ export default {
             type: Object,
             default: () => {},
         },
+        districtQuery: {
+            type: String,
+            default: '',
+        }
     },
     data () {
         return {
@@ -189,7 +193,12 @@ export default {
         },
     },
     created () {
-        this.getDistrictList();
+        if (this.districtQuery) {
+            this.location = 'city';
+            this.buttonHandleInSide(this.districtQuery, false);
+        } else {
+            this.getDistrictList();
+        }
 
         Bus.$on('district-selected', areaName => {
             this.buttonHandleInSide(areaName, false);

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -34,60 +34,14 @@
                             Die 9 Stadtbezirke in Köln
                         </div>
                         <div>
-                            <a href="{{ route('theme-overview', 'district=Innenstadt') }}"
-                                class="ris-link ris-button ris-button_secondary ris-button_has-shadow"
-                                title="Innenstadt"
-                            >
-                                Innenstadt
-                            </a>
-                            <a href="{{ route('theme-overview', 'district=Rodenkirchen') }}"
-                                class="ris-link ris-button ris-button_secondary ris-button_has-shadow"
-                                title="Rodenkirchen"
-                            >
-                                Rodenkirchen
-                            </a>
-                            <a href="{{ route('theme-overview', 'district=Lindenthal') }}"
-                                class="ris-link ris-button ris-button_secondary ris-button_has-shadow"
-                                title="Lindenthal"
-                            >
-                                Lindenthal
-                            </a>
-                            <a href="{{ route('theme-overview', 'district=Ehrenfeld') }}"
-                                class="ris-link ris-button ris-button_secondary ris-button_has-shadow"
-                                title="Ehrenfeld"
-                            >
-                                Ehrenfeld
-                            </a>
-                            <a href="{{ route('theme-overview', 'district=Nippes') }}"
-                                class="ris-link ris-button ris-button_secondary ris-button_has-shadow"
-                                title="Nippes"
-                            >
-                                Nippes
-                            </a>
-                            <a href="{{ route('theme-overview', 'district=Chorweiler') }}"
-                                class="ris-link ris-button ris-button_secondary ris-button_has-shadow"
-                                title="Chorweiler"
-                            >
-                                Chorweiler
-                            </a>
-                            <a href="{{ route('theme-overview', 'district=Porz') }}"
-                                class="ris-link ris-button ris-button_secondary ris-button_has-shadow"
-                                title="Porz"
-                            >
-                                Porz
-                            </a>
-                            <a href="{{ route('theme-overview', 'district=Kalk') }}"
-                                class="ris-link ris-button ris-button_secondary ris-button_has-shadow"
-                                title="Kalk"
-                            >
-                                Kalk
-                            </a>
-                            <a href="{{ route('theme-overview', 'district=Mülheim') }}"
-                                class="ris-link ris-button ris-button_secondary ris-button_has-shadow"
-                                title="Mülheim"
-                            >
-                                Mülheim
-                            </a>
+                            @foreach ($district_list as $district)
+                                <a href="{{ route('map', 'district=' . $district) }}"
+                                    class="ris-link ris-button ris-button_secondary ris-button_has-shadow"
+                                    title="{{ $district }}"
+                                >
+                                    {{ $district }}
+                                </a>
+                            @endforeach
                         </div>
                     </div>
                 </section>


### PR DESCRIPTION
- updated welcome page link from topic to the Map district area
- added catch the query with district name on the Map page(for map, navigation, topic list)
- updated the district list according to alphabet on the all site