### PR TITLE
Breadcrumbs-typos-and-paper-query-empty-error-on-theme-list, closed #88

### DIFF
--- a/app/Http/Controllers/PersonenController.php
+++ b/app/Http/Controllers/PersonenController.php
@@ -35,7 +35,7 @@ class PersonenController extends Controller
             'members' => $peopleData->data,
             'links' => $peopleData->links,
             'breadcrumbs' => [
-                'Personen' => route('theme-overview'),
+                'Personen' => route('people-list'),
             ]
         ]);
     }

--- a/app/Http/Controllers/TopicController.php
+++ b/app/Http/Controllers/TopicController.php
@@ -180,28 +180,23 @@ class TopicController extends Controller
         $postalCode = $request->input('postalCode');
 
         $district = $request->input('district');
-        $topicTitle = '';
 
         $section=$request->input('section');
 
-        if($section === 'new'){
-            $paperQuery = Paper::with(Paper::$basicScope)->sort()->new();
-            $breadcrumbs = ['Neue Themen' => route('themes')];
-            $topicTitle = 'Neue Themen';
-        }
-
         if($section === 'updated'){
             $paperQuery = Paper::with(Paper::$basicScope)->sort()->updated();
-            $breadcrumbs = ['Aktualisierte Themen' => route('themes')];
+            $breadcrumbs = ['Aktualisierte Themen' => route('themes', 'section=updated')];
             $topicTitle = 'Kürzlich aktualisiert';
-        }
-
-        if($section === 'finished'){
+        } elseif ($section === 'finished'){
             $paperQuery = Paper::with(Paper::$basicScope)->sort()->finished();
-            $breadcrumbs = ['Abgeschlossene Themen' => route('themes')];
+            $breadcrumbs = ['Abgeschlossene Themen' => route('themes', 'section=finished')];
             $topicTitle = 'Kürzlich abgeschlossen';
+        } else {
+            // the 'new' topic type by default if section type not exist or pass by direct link
+            $paperQuery = Paper::with(Paper::$basicScope)->sort()->new();
+            $breadcrumbs = ['Neue Themen' => route('themes', 'section=new')];
+            $topicTitle = 'Neue Themen';
         }
-
 
         if ($postalCode) {
             $paperQuery->whereHas('locations', function (Builder $query) use ($postalCode) {


### PR DESCRIPTION
- fixed the breadcrumbs typo on the 'personen-liste'
- added the theme type in the breadcrumbs on the theme page
- added the theme new type by default on theme list by type(fixed direct link error)